### PR TITLE
Nova demo requires USB HID driver of dde_linux

### DIFF
--- a/foundations/getting_started.txt
+++ b/foundations/getting_started.txt
@@ -372,6 +372,13 @@ microhypervisor, the following preparatory steps are needed:
 
   The source code will be downloaded to _<genode-dir>/contrib/x86emu-<hash>/_.
 
+# To handle USB devices, a device-driver environment for executing a Linux
+  kernel subsystem as a user-level component is used. Download the 3rd-party
+  source code of the _dde_linux_ repository:
+  ! <genode-dir>/tool/ports/prepare_port dde_linux
+
+  The source code will be downloaded to _<genode-dir>/contrib/dde_linux-<hash>/_.
+
 # To boot the scenario as an operating system on a PC, a boot loader is
   needed. The build process produces a bootable disk or ISO image
   that includes the GRUB2 boot loader as well as a working boot-loader
@@ -384,9 +391,10 @@ microhypervisor, the following preparatory steps are needed:
   can keep using the existing build directory that we just used for Linux.
   However, apart from enabling the parallelization of the build process as
   mentioned in Section [Using the build system], we need to incorporate
-  the _libports_ source-code repository into the build process by uncommenting
-  the corresponding line in the configuration. Otherwise the build system
-  would fail to build the VESA driver, which resides within _libports/_.
+  the _libports_ and _dde_linux_ source-code repositories into the build
+  process by uncommenting the corresponding lines in the configuration.
+  Otherwise the build system would fail to build the VESA and USB HID drivers,
+  which reside within _libports/_ and _dde_linux/_, respectively.
 
 With those preparations in place, issue the execution of the demo run
 script from within the build directory:


### PR DESCRIPTION
Following the instructions of the "Getting started" chapter, "A simple
system scenario" section, "Targeting a microkernel" paragraph, an error
occurs when running "make run/demo KERNEL=nova BOARD=pc", namely:

	$ make run/demo KERNEL=nova BOARD=pc
	including /home/u/Desktop/genode_play/genode/tool/run/power_on/qemu
	including /home/u/Desktop/genode_play/genode/tool/run/log/qemu
	including /home/u/Desktop/genode_play/genode/tool/run/image/iso
	including /home/u/Desktop/genode_play/genode/tool/run/boot_dir/nova
	including /home/u/Desktop/genode_play/genode/repos/os/run/demo.run
	update depot: /home/u/Desktop/genode_play/genode/tool/depot/create genodelabs/bin/x86_64/base-nova genodelabs/bin/x86_64/demo genodelabs/bin/x86_64/global_keys_handler genodelabs/bin/x86_64/init genodelabs/bin/x86_64/nit_focus genodelabs/bin/x86_64/nitpicker genodelabs/bin/x86_64/report_rom genodelabs/bin/x86_64/rom_filter genodelabs/pkg/x86_64/drivers_interactive-pc CROSS_DEV_PREFIX=/usr/local/genode/tool/21.05/bin/genode-x86- DEPOT_DIR=/home/u/Desktop/genode_play/genode/depot UPDATE_VERSIONS=1 FORCE=1 REBUILD=
	make[1]: Entering directory '/home/u/Desktop/genode_play/genode/build/x86_64'
	Error: incomplete or missing recipe (genodelabs/src/usb_hid_drv genodelabs/src/usb_host_drv)

This commit adds instructions for including the dde_linux source-code
repository in the build to resolve this issue.