### PR TITLE
Remove duplicated Capture Session Interface in api.txt

### DIFF
--- a/foundations/api.txt
+++ b/foundations/api.txt
@@ -954,27 +954,6 @@ how portions of the virtual framebuffer are composed on screen.
 
 [raw spec/clearpage]
 
-Capture session interface
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-; XXX description, reference to components section
-
-; XXX Framebuffer::Session_client
-
-; Framebuffer::Transfer
-; Framebuffer::Blit_batch
-; Framebuffer::Mode
-[raw spec/classes/framebuffer/mode/description]
-
-; Capture::Session
-[raw spec/classes/capture/session/description]
-
-; Capture::Connection
-[raw spec/classes/capture/connection/description]
-
-
-[raw spec/clearpage]
-
 Platform session interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Removes duplicated Capture Session.

NOTE !!! The two versions are NOT identical (despite appearing that way in the generated HTML)
(Here's an online diff: https://www.diffchecker.com/dTcVzoOl/ )

I believe anything starting with a ';' is a comment, so only the comments are different, but I'm not sure which one is closer to right.

The correct location for the Capture Session is before GUI to match Section 4.

(Other note: Section 4 has Event before Capture, but this is not in Section 8 - Is this intentional?)